### PR TITLE
Circleci editor/441/main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ jobs:
       - run:
           name: Install Python Dependencies
           command: |
-            python -m venv env
             pip install --user -r requirements.txt
       - run:
           name: Run Unit Tests


### PR DESCRIPTION
A line of bash commands in the config file was calling a command not present in the CircleCI directory path

Test created doesn't work for now, but we only needed to make the pipeline work

Closes #44 